### PR TITLE
Added mapType

### DIFF
--- a/lib/src/widgets/place_picker.dart
+++ b/lib/src/widgets/place_picker.dart
@@ -51,6 +51,11 @@ class PlacePicker extends StatefulWidget {
   /// Used to receive a [GoogleMapController] for this [GoogleMap].
   final MapCreatedCallback? onMapCreated;
 
+  /// Type of map to be displayed
+  ///
+  /// Defaults to [MapType.normal]
+  final MapType? mapType;
+
   /// Location to be displayed when screen is showed. If this is set or not null, the
   /// map does not pan to the user's current location.
   final LatLng? initialLocation;
@@ -149,6 +154,7 @@ class PlacePicker extends StatefulWidget {
     this.onMapCreated,
     this.initialLocation,
     this.onPlacePicked,
+    this.mapType,
     this.minMaxZoomPreference = const MinMaxZoomPreference(0, 16.0),
     this.localizationConfig = const LocalizationConfig.init(),
     this.showSearchInput = true,
@@ -337,6 +343,7 @@ class PlacePickerState extends State<PlacePicker>
       ),
       minMaxZoomPreference: widget.minMaxZoomPreference,
       myLocationEnabled: widget.myLocationEnabled,
+      mapType: widget.mapType ?? MapType.normal,
       onTap: onTap,
       markers: markers,
       myLocationButtonEnabled: false,


### PR DESCRIPTION
Summary
This pull request adds the mapType option to the PlacePicker widget, allowing users to specify the type of map to be displayed. If not provided, the option defaults to MapType.normal.